### PR TITLE
Change in logical symbols

### DIFF
--- a/ISCE2GBIS.m
+++ b/ISCE2GBIS.m
@@ -333,10 +333,10 @@ end
 
 %crop area
 if crop_flag==1
-    crop_lim=find(GBIS(:,1)>crop(:,1) & GBIS(:,1)<crop(:,2) & GBIS(:,2)>crop(:,3) & GBIS(:,2)<crop(:,4));
+    crop_lim=find(GBIS(:,1)<crop(:,1) & GBIS(:,1)>crop(:,2) & GBIS(:,2)>crop(:,3) & GBIS(:,2)<crop(:,4));
     GBIS=GBIS(crop_lim,:);
  if exist('cp_flag')    
-     crop_lim=find(CONN_PARTS(:,1)>crop(:,1) & CONN_PARTS(:,1)<crop(:,2) & CONN_PARTS(:,2)>crop(:,3) & CONN_PARTS(:,2)<crop(:,4));
+     crop_lim=find(CONN_PARTS(:,1)<crop(:,1) & CONN_PARTS(:,1)>crop(:,2) & CONN_PARTS(:,2)>crop(:,3) & CONN_PARTS(:,2)<crop(:,4));
      CONN_PARTS=CONN_PARTS(crop_lim,:);
  end
 end


### PR DESCRIPTION
I would proposed to change the greater than and less than sign in lines 336 and 339 since the cropping argument says lon max, lon min, lat min and lat max (e.g. 121, 120, 12, 13). The logic before for line 336 is GBIS(:,1)>121, GBIS(:,1)<120, GBIS(:,2) >12 & GBIS(:,2)<13. The proposed logic now is GBIS(:,1)<121, GBIS(:,1)>120, GBIS(:,2) >12 & GBIS(:,2)<13.